### PR TITLE
Fix: Deprecated Functionality: Creation of dynamic property 

### DIFF
--- a/Cron/GetUpdate.php
+++ b/Cron/GetUpdate.php
@@ -59,6 +59,11 @@ class GetUpdate
     protected $readFactory;
 
     /**
+     * @var NotifierPool
+     */
+    protected $notifierPool;
+
+    /**
      * @var LoggerInterface
      */
     protected $logger;


### PR DESCRIPTION
Fix: Deprecated Functionality: Creation of dynamic property in GetUpate::$notifierPool

Magento 2.4.6
PHP 8.2

![SCR-20230604-lo6](https://github.com/mageplaza/module-core/assets/46677994/23729b59-3e01-4808-a504-0de6a759e22c)
