### PR TITLE
Add laminas-http dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,9 @@
   "type": "magento2-module",
   "version": "1.5.6",
   "license": "proprietary",
+  "require": {
+    "laminas/laminas-http": "^2.13"
+  },
   "authors": [
     {
       "name": "Mageplaza",


### PR DESCRIPTION
As Mageplaza\Core\Model\Activate uses Laminas\Http\Request it may be better to add it as a dependency for older magento versions (like 2.3)