### PR TITLE
Fix map scope in requirejs-config.js - global '*' override breaks third-party modules

### DIFF
--- a/view/base/requirejs-config.js
+++ b/view/base/requirejs-config.js
@@ -20,7 +20,10 @@
 
 var config = {
     map: {
-        '*': {
+        'touchPunch': {
+            'jquery-ui-modules/core': 'jquery-ui-modules/widget'
+        },
+        'Mageplaza_Core/js/jquery.ui.touch-punch.min': {
             'jquery-ui-modules/core': 'jquery-ui-modules/widget'
         }
     },


### PR DESCRIPTION
Problem
Version 1.5.16 added a global map entry that redirects jquery-ui-modules/core → jquery-ui-modules/widget for all modules:
```
var config = {
    map: {
        '*': {
            'jquery-ui-modules/core': 'jquery-ui-modules/widget'
        }
    },
    paths: { ... },
    shim: { ... }
};
```

This overrides Magento's correct base mapping (jquery-ui-modules/core → jquery/ui-modules/core) for the entire application. Modules that legitimately depend on jquery-ui-modules/core - such as Magento_Ui/js/modal/modal, Magento_Checkout/js/view/shipping, and various checkout components - get their dependency silently redirected to jquery-ui-modules/widget, causing a cascading module-loading failure (43+ modules stuck in RequireJS pending state).

Root Cause
The touchPunch shim depends on jquery-ui-modules/core. Since jquery/ui-modules/core.js was deprecated in jQuery UI 1.12.0 (to be removed in 1.14), the intent was to ensure touchPunch still loads when core.js is removed in a future Magento version. However, using '*' as the scope applies this redirect to every module, not just touchPunch.

Fix
Scope the override to only the modules that actually need it:
```
var config = {
    map: {
        'touchPunch': {
            'jquery-ui-modules/core': 'jquery-ui-modules/widget'
        },
        'Mageplaza_Core/js/jquery.ui.touch-punch.min': {
            'jquery-ui-modules/core': 'jquery-ui-modules/widget'
        }
    },
    paths: { ... },
    shim: { ... }
};
```
Or, since Magento 2.4.7-p10 still ships jquery/ui-modules/core.js, the entry can simply be removed until core.js is actually dropped.

Testing
- Checkout page loads all components without RequireJS stalls
- touchPunch functionality works as expected
- No regression in Mageplaza module dependencies